### PR TITLE
Forcing compiling CXX files with GNU++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 target_compile_options(${COMPONENT_LIB}
     PUBLIC
         -Wno-missing-field-initializers
+        $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++20>
 )
 
 if(NOT ESP_PLATFORM)


### PR DESCRIPTION
Aims at resolving https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues/216 when compiling through esp32_display_panel in ESP-IDF.